### PR TITLE
Fix comparison always evaluating to false

### DIFF
--- a/psvpfsparser/UnicvDbParser.cpp
+++ b/psvpfsparser/UnicvDbParser.cpp
@@ -313,7 +313,7 @@ int parseUnicvDb(boost::filesystem::path titleIdPath, scei_rodb_t& fdb)
       return -1;
    }
 
-   if(parseUnicvDb(inputStream, fdb) < 0)
+   if(!parseUnicvDb(inputStream, fdb))
       return -1;
 
    return 0;


### PR DESCRIPTION
The `parseUnicvDb(std::ifstream&, scei_rodb_t&)` function called here is a bool, not an int.  
Neither boolean value evaluates as less than zero, so this condition as originally written will never work.

![image](https://user-images.githubusercontent.com/2524348/32713824-9968622a-c810-11e7-9358-ec5e2b44ff76.png)
