### PR TITLE
 Fix compilation on Ubuntu Linux 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ You have to set these environment variables for cmake:
 - LIBTOMCRYPT_INCLUDE_DIR=C:\libtomcrypt\build\include
 - LIBTOMCRYPT_LIBRARY=C:\libtomcrypt\build\lib\tomcrypt.lib
 
+#### Ubuntu (example)
+You can install libtomcrypt with apt-get:
+
+```bash
+apt-get install libtomcrypt1 libtomcrypt-dev
+```
+
 ### curl
 
 #### Windows (example)

--- a/cmake/build.sh
+++ b/cmake/build.sh
@@ -2,5 +2,5 @@ rm build -r -f
 mkdir build
 cd build
 cmake ../ -DCMAKE_BUILD_TYPE=Release
-make
+make -j$(nproc)
 cd ..

--- a/cmake/scripts/ConfigureDependencies.cmake
+++ b/cmake/scripts/ConfigureDependencies.cmake
@@ -83,7 +83,7 @@ set(LIBTOMCRYPT_INCLUDE_DIR "$ENV{LIBTOMCRYPT_INCLUDE_DIR}")
 set(LIBTOMCRYPT_LIBRARY "$ENV{LIBTOMCRYPT_LIBRARY}")
 endif()
 
-find_package(LIBTOMCRYPT REQUIRED)
+find_package(LibTomCrypt REQUIRED)
 
 if(LIBTOMCRYPT_FOUND)
 message("Found libtomcrypt library")

--- a/cmake/scripts/FindLibTomCrypt.cmake
+++ b/cmake/scripts/FindLibTomCrypt.cmake
@@ -7,6 +7,12 @@
 # LIBTOMCRYPT_INCLUDE_DIRS - The LIBTOMCRYPT include directories
 # LIBTOMCRYPT_LIBRARIES - The libraries needed to use LIBTOMCRYPT
 
+if(NOT "${LIBTOMCRYPT_INCLUDE_DIR}" AND NOT "${LIBTOMCRYPT_LIBRARY}")
+   # If neither helper variables are set, try to use PkgConfig.
+   find_package(PkgConfig)
+   pkg_check_modules(LIBTOMCRYPT libtomcrypt)
+endif()
+
 if(${LIBTOMCRYPT_INCLUDE_DIR})
    set(LIBTOMCRYPT_LIBRARIES ${LIBTOMCRYPT_LIBRARY})
 else()

--- a/psvpfsparser/IcvPrimitives.cpp
+++ b/psvpfsparser/IcvPrimitives.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+
 #include "IcvPrimitives.h"
 
 #include "SceKernelUtilsForDriver.h"
@@ -18,8 +20,8 @@ int icv_contract(std::shared_ptr<ICryptoOperations> cryptops, unsigned char *res
 {
    unsigned char combo[0x28] = {0};
 
-   memcpy(combo, left_hash, 0x14);
-   memcpy(combo + 0x14, right_hash, 0x14);
+   std::memcpy(combo, left_hash, 0x14);
+   std::memcpy(combo + 0x14, right_hash, 0x14);
 
    SceKernelUtilsForDriver_sceSha1DigestForDriver(cryptops, combo, 0x28, result);
    return 0;

--- a/psvpfsparser/SecretGenerator.cpp
+++ b/psvpfsparser/SecretGenerator.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <stdexcept>
+#include <cstring>
 
 #include "PfsKeys.h"
 #include "IcvPrimitives.h"
@@ -31,7 +32,7 @@ int gen_secret(std::shared_ptr<ICryptoOperations> cryptops, unsigned char* combo
       icv_set_hmac_sw(cryptops, base, hmac_key1, (unsigned char*)saltin1, 8); // derive base with two salts
    }
 
-   memcpy(combo, base, 0x14); // calculated digest will be src data
+   std::memcpy(combo, base, 0x14); // calculated digest will be src data
 
    return 0;
 }
@@ -46,11 +47,11 @@ int generate_secret_np(std::shared_ptr<ICryptoOperations> cryptops, std::shared_
 
    gen_secret(cryptops, combo, files_salt, icv_salt);
 
-   memcpy(iv, iv0, 0x10); //initialize iv
+   std::memcpy(iv, iv0, 0x10); //initialize iv
 
    AESCBCEncryptWithKeygen_base(cryptops, iF00D, klicensee, iv, 0x14, combo, drvkey, key_id);
 
-   memcpy(secret, drvkey, 0x14); // copy derived key
+   std::memcpy(secret, drvkey, 0x14); // copy derived key
    
    return 0;
 }
@@ -73,7 +74,7 @@ int generate_secret(std::shared_ptr<ICryptoOperations> cryptops, unsigned char* 
 
    icv_contract(cryptops, drvkey, base0, base1); // calculate digest of combination of klicensee and salt digests
                
-   memcpy(secret, drvkey, 0x14); // copy derived key
+   std::memcpy(secret, drvkey, 0x14); // copy derived key
 
    return 0;
 }
@@ -86,7 +87,7 @@ int scePfsUtilGetSecret(std::shared_ptr<ICryptoOperations> cryptops, std::shared
    {
       throw std::runtime_error("Untested branch in scePfsUtilGetSecret");
 
-      memset(secret, 0, 0x14);
+      std::memset(secret, 0, 0x14);
       return 0;
    }
    else if(crypto_engine_flag & CRYPTO_ENGINE_CRYPTO_USE_KEYGEN)


### PR DESCRIPTION
This tweaks a few things to make it compile out-of-the-box in 18.04:
* Use PkgConfig to look up libtomcrypt if helper variables aren't set
* Explicitly include <cstring> and use std::memset and std::memcpy
* Detect the number of cores and parallelize the build